### PR TITLE
Use the futures-lite block_on function instead of the async-std one

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,7 +285,7 @@ checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
 
 [[package]]
 name = "asserhttp"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "actix-http",
  "actix-web",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,6 +293,7 @@ dependencies = [
  "asserhttp",
  "async-std",
  "awc",
+ "futures-lite",
  "http-types",
  "hyper",
  "isahc 1.7.0",
@@ -1135,9 +1136,9 @@ checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
 
 [[package]]
 name = "futures-lite"
-version = "1.11.3"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4481d0cd0de1d204a4fa55e7d45f07b1d958abcb06714b3446438e2eff695fb"
+checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
 dependencies = [
  "fastrand",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ include = ["/src/*", "/tests/*", "/Cargo.toml"]
 
 [dependencies]
 anyhow = "1.0.56"
-async-std = { version = "1.11.0", features = ["alloc"], default-features = false }
+futures-lite = { version = "1.12.0", features = ["std"], default-features = false }
 serde = "1.0.136"
 serde_json = "1.0.79"
 regex = { version = "1.5.5", features = ["std", "unicode"], default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asserhttp"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 authors = ["Beltram Maldant"]
 description = "Fluent http response assertions"

--- a/src/assert_awc/body.rs
+++ b/src/assert_awc/body.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Debug, panic::panic_any};
 
-use async_std::task::block_on;
+use futures_lite::future::block_on;
 use awc::error::SendRequestError as AwcError;
 use serde::{de::DeserializeOwned, Serialize};
 

--- a/src/assert_hyper/body.rs
+++ b/src/assert_hyper/body.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Debug, panic::panic_any};
 
-use async_std::task::block_on;
+use futures_lite::future::block_on;
 use hyper::{
     Body as HyperBody,
     body::HttpBody,

--- a/src/assert_isahc/body.rs
+++ b/src/assert_isahc/body.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Debug, panic::panic_any};
 
-use async_std::task::block_on;
+use futures_lite::future::block_on;
 use isahc::{AsyncBody as IsahcAsyncBody, AsyncReadResponseExt, Body as IsahcBody, Error as IsahcError, ReadResponseExt, Response as IsahcResponse};
 use serde::{de::DeserializeOwned, Serialize};
 

--- a/src/assert_reqwest/body.rs
+++ b/src/assert_reqwest/body.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Debug, panic::panic_any};
 
-use async_std::task::block_on;
+use futures_lite::future::block_on;
 use reqwest::{blocking::Response as ReqwestResponse, Error as ReqwestError, Response as AsyncReqwestResponse};
 use serde::{de::DeserializeOwned, Serialize};
 

--- a/src/assert_rocket/body.rs
+++ b/src/assert_rocket/body.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Debug, io::Read, panic::panic_any, str::from_utf8};
 
-use async_std::task::block_on;
+use futures_lite::future::block_on;
 use rocket::{
     local::{
         asynchronous::LocalResponse as AsyncRocketResponse,

--- a/src/assert_surf/body.rs
+++ b/src/assert_surf/body.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Debug, panic::panic_any};
 
-use async_std::task::block_on;
+use futures_lite::future::block_on;
 use serde::{de::DeserializeOwned, Serialize};
 use surf::{Error as SurfError, Response as SurfResponse};
 


### PR DESCRIPTION
The function `async_std::task::block_on` requires the feature `default` of the crate `async-std`. To avoid using `async-std` with default features - use the function `futures_lite::future::block_on`.